### PR TITLE
feat: allow inspection submit with cash difference

### DIFF
--- a/PreSotuken/src/main/resources/templates/admin/inspectionForm.html
+++ b/PreSotuken/src/main/resources/templates/admin/inspectionForm.html
@@ -206,7 +206,7 @@ th, td {
 				name="performWithdrawal" value="true" /> 出金も行う (現金合計をレジから出金)
 			</label>
 		</div>
-		<button id="submitBtn" type="submit" disabled>登録</button>
+                <button id="submitBtn" type="submit">登録</button>
 		<span id="expectedCashCalculated" th:text="${expectedCash ?: 0}"
 			style="display: none;">0</span>
 
@@ -219,7 +219,6 @@ th, td {
     const expectedCashEl = document.getElementById('expectedCashCalculated'); // IDを修正済みだね！
     
     // 新しく追加
-    const submitBtn = document.getElementById('submitBtn');
     const performWithdrawalCheck = document.getElementById('performWithdrawalCheck');
 
     function calculate() {
@@ -236,13 +235,6 @@ th, td {
         cashTotalEl.textContent = total.toLocaleString();
         expectedTotalEl.textContent = expected.toLocaleString();
         differenceEl.textContent = diff.toLocaleString();
-
-        // ★差額が0でない場合は登録ボタンを無効にするロジック★
-        if (diff !== 0) {
-            submitBtn.disabled = true;
-        } else {
-            submitBtn.disabled = false;
-        }
     }
 
     inputs.forEach(input => {


### PR DESCRIPTION
## Summary
- Enable inspection form submission even when expected and counted cash differ

## Testing
- ⚠️ `./gradlew test` *(Unable to tunnel through proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b64d7f6afc8328ae71bdc595c06d24