### PR TITLE
Add payment history page and navigation link

### DIFF
--- a/PreSotuken/src/main/java/com/order/controller/PaymentController.java
+++ b/PreSotuken/src/main/java/com/order/controller/PaymentController.java
@@ -81,6 +81,14 @@ public class PaymentController {
         return "payment";
     }
 
+    @GetMapping("/payments/history")
+    public String showPaymentHistory(@CookieValue(name = "storeId", required = false) Integer storeId,
+                                     Model model) {
+        List<Payment> payments = paymentRepository.findByStoreStoreIdOrderByPaymentTimeDesc(storeId);
+        model.addAttribute("payments", payments);
+        return "paymentHistory";
+    }
+
 
     //会計確定: Payment および Visit の退店時刻を更新
 

--- a/PreSotuken/src/main/java/com/order/repository/PaymentRepository.java
+++ b/PreSotuken/src/main/java/com/order/repository/PaymentRepository.java
@@ -2,6 +2,7 @@ package com.order.repository;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +15,8 @@ import com.order.entity.Payment;
 public interface PaymentRepository extends JpaRepository<Payment, Integer> {
 
     Payment findByVisitVisitId(int visitId);
+
+    List<Payment> findByStoreStoreIdOrderByPaymentTimeDesc(Integer storeId);
 
 
 

--- a/PreSotuken/src/main/resources/static/css/payment-history.css
+++ b/PreSotuken/src/main/resources/static/css/payment-history.css
@@ -1,0 +1,19 @@
+body {
+    font-family: sans-serif;
+    padding: 20px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #f2f2f2;
+}

--- a/PreSotuken/src/main/resources/templates/paymentHistory.html
+++ b/PreSotuken/src/main/resources/templates/paymentHistory.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>会計履歴</title>
+    <link rel="stylesheet" href="/css/payment-history.css">
+</head>
+<body>
+<h1>会計履歴</h1>
+<table>
+    <thead>
+    <tr>
+        <th>日時</th>
+        <th>席</th>
+        <th>合計</th>
+        <th>担当</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="payment : ${payments}">
+        <td th:text="${#temporals.format(payment.paymentTime, 'yyyy-MM-dd HH:mm')}"></td>
+        <td th:text="${payment.visit.seat.seatName}"></td>
+        <td th:text="${#numbers.formatDecimal(payment.total,0,0)} + '円'"></td>
+        <td th:text="${payment.cashier != null ? payment.cashier.userName : ''}"></td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/PreSotuken/src/main/resources/templates/seat-list.html
+++ b/PreSotuken/src/main/resources/templates/seat-list.html
@@ -32,11 +32,12 @@
 			<a th:href="@{/admin/terminals/logo}">ロゴ設定</a>
 			<a th:href="@{/admin/store/edit}">店舗設定</a>
 			<a th:href="@{/admin/inspection/form}">点検</a>
-			<a th:href="@{/admin/cash/transaction}">入出金</a>
-			<a th:href="@{/admin/cash/history}">入出金履歴</a>
-			
-			
-		</div>
+                        <a th:href="@{/admin/cash/transaction}">入出金</a>
+                        <a th:href="@{/admin/cash/history}">入出金履歴</a>
+                        <a href="/payments/history">会計履歴</a>
+
+
+                </div>
 		
 		<form th:action="@{/logout}" method="get" onsubmit="clearUserIdCookie()">
 		    <button type="submit">ログアウト</button>


### PR DESCRIPTION
## Summary
- Add repository method and controller endpoint to display payment history
- Create paymentHistory template and styles
- Link payment history from seat list menu

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6508332608328869d2faad5b682f5