### PR TITLE
Add payment history menu link

### DIFF
--- a/PreSotuken/src/main/resources/templates/seat-list.html
+++ b/PreSotuken/src/main/resources/templates/seat-list.html
@@ -32,9 +32,10 @@
 			<a th:href="@{/admin/terminals/logo}">ロゴ設定</a>
 			<a th:href="@{/admin/store/edit}">店舗設定</a>
 			<a th:href="@{/admin/inspection/form}">点検</a>
-			<a th:href="@{/admin/cash/transaction}">入出金</a>
-			<a th:href="@{/admin/cash/history}">入出金履歴</a>
-			<a th:href="@{/seat/edit}">座席グループ・座席編集</a>
+                        <a th:href="@{/admin/cash/transaction}">入出金</a>
+                        <a th:href="@{/admin/cash/history}">入出金履歴</a>
+                        <a th:href="@{/payments/history}">会計履歴</a>
+                        <a th:href="@{/seat/edit}">座席グループ・座席編集</a>
 			
 		</div>
 		


### PR DESCRIPTION
## Summary
- add link to payment history from seat list menu

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b68412baf48328bfe4553a3992f427