### PR TITLE
Group seat list menu links into collapsible categories

### DIFF
--- a/PreSotuken/src/main/resources/static/css/seat-list.css
+++ b/PreSotuken/src/main/resources/static/css/seat-list.css
@@ -73,7 +73,38 @@ body{
 }
 
 .menu-drawer a:hover {
-	text-decoration: underline;
+        text-decoration: underline;
+}
+
+.menu-group {
+        margin-bottom: 24px;
+}
+
+.menu-group-title {
+        margin: 0;
+        font-size: 18px;
+        font-weight: bold;
+        cursor: pointer;
+        margin-bottom: 8px;
+}
+
+.menu-group-title::-webkit-details-marker {
+        display: none;
+}
+
+.menu-group-title::before {
+        content: "\25B6"; /* ▶ */
+        display: inline-block;
+        margin-right: 6px;
+        transition: transform 0.2s;
+}
+
+.menu-group[open] > .menu-group-title::before {
+        transform: rotate(90deg);
+}
+
+.menu-group a {
+        padding-left: 20px;
 }
 
 /*↑↑↑↑メニュー部分↑↑↑↑*/

--- a/PreSotuken/src/main/resources/templates/seat-list.html
+++ b/PreSotuken/src/main/resources/templates/seat-list.html
@@ -20,30 +20,40 @@
     <button onclick="openCallListModal()">呼び出し状況確認</button>
     
     
-	<nav id="menuDrawer" class="menu-drawer">
-		<div>
-			<a href="/menu/list">メニュー管理</a>
-			<a href="/menu/group/add">メニューグループ管理</a>
-			<a href="/options">オプション管理</a>
-			<a href="/admin/printers" >プリンター管理</a>
-			<a href="/menu/sold-out-management">メニュー品切れ管理</a>
-			<a href="/admin/plans">プラン管理</a>
-			<a href="/admin/terminals">端末管理</a>
-			<a th:href="@{/admin/terminals/logo}">ロゴ設定</a>
-			<a th:href="@{/admin/store/edit}">店舗設定</a>
-			<a th:href="@{/admin/inspection/form}">点検</a>
-                        <a th:href="@{/admin/cash/transaction}">入出金</a>
-                        <a th:href="@{/admin/cash/history}">入出金履歴</a>
-                        <a th:href="@{/payments/history}">会計履歴</a>
-                        <a th:href="@{/payment-types}">支払い方法管理</a>
-                        <a th:href="@{/seat/edit}">座席グループ・座席編集</a>
-			
-		</div>
-		
-		<form th:action="@{/logout}" method="get" onsubmit="clearUserIdCookie()">
-		    <button type="submit">ログアウト</button>
-		</form>
-	</nav>
+        <nav id="menuDrawer" class="menu-drawer">
+            <div>
+                <details class="menu-group" open>
+                    <summary class="menu-group-title">メニューに関する操作</summary>
+                    <a href="/menu/list">メニュー管理</a>
+                    <a href="/menu/group/add">メニューグループ管理</a>
+                    <a href="/options">オプション管理</a>
+                    <a href="/menu/sold-out-management">メニュー品切れ管理</a>
+                </details>
+
+                <details class="menu-group" open>
+                    <summary class="menu-group-title">お金に関する操作</summary>
+                    <a th:href="@{/admin/cash/transaction}">入出金</a>
+                    <a th:href="@{/admin/cash/history}">入出金履歴</a>
+                    <a th:href="@{/payments/history}">会計履歴</a>
+                    <a th:href="@{/payment-types}">支払い方法管理</a>
+                </details>
+
+                <details class="menu-group" open>
+                    <summary class="menu-group-title">店舗に関する操作</summary>
+                    <a href="/admin/printers" >プリンター管理</a>
+                    <a href="/admin/plans">プラン管理</a>
+                    <a href="/admin/terminals">端末管理</a>
+                    <a th:href="@{/admin/terminals/logo}">ロゴ設定</a>
+                    <a th:href="@{/admin/store/edit}">店舗設定</a>
+                    <a th:href="@{/admin/inspection/form}">点検</a>
+                    <a th:href="@{/seat/edit}">座席グループ・座席編集</a>
+                </details>
+            </div>
+
+            <form th:action="@{/logout}" method="get" onsubmit="clearUserIdCookie()">
+                <button type="submit">ログアウト</button>
+            </form>
+        </nav>
 
 	<div  th:each="entry : ${groupedSeats}" class="group">
 		<h3 class="groupTitle" th:text="${entry.key.seatGroupName}">グループ名</h3>


### PR DESCRIPTION
## Summary
- Group seat list menu links under headings for menu, money, and store operations
- Make each menu group collapsible with summary toggles and arrow indicators

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68b68ea3c1808328a697861b15df06e1