### PR TITLE
Add daily sales analysis page

### DIFF
--- a/PreSotuken/src/main/java/com/order/controller/SalesAnalysisController.java
+++ b/PreSotuken/src/main/java/com/order/controller/SalesAnalysisController.java
@@ -1,0 +1,93 @@
+package com.order.controller;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.order.entity.Payment;
+import com.order.repository.PaymentDetailRepository;
+import com.order.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Controller
+public class SalesAnalysisController {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentDetailRepository paymentDetailRepository;
+
+    @GetMapping("/sales-analysis")
+    public String showDailySales(
+            @CookieValue(name = "storeId", required = false) Integer storeId,
+            @RequestParam(name = "date", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            Model model) {
+        if (date == null) {
+            date = LocalDate.now();
+        }
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        List<Payment> payments = paymentRepository
+                .findByStoreStoreIdAndPaymentTimeBetween(storeId, startOfDay, endOfDay);
+
+        double[] hourlySales = new double[24];
+        int[] hourlyCustomers = new int[24];
+        for (Payment p : payments) {
+            if (p.getPaymentTime() == null) continue;
+            int hour = p.getPaymentTime().getHour();
+            double total = p.getTotal() != null ? p.getTotal() : 0;
+            hourlySales[hour] += total;
+            if (p.getVisit() != null && p.getVisit().getNumberOfPeople() != null) {
+                hourlyCustomers[hour] += p.getVisit().getNumberOfPeople();
+            }
+        }
+
+        List<Map<String, Object>> hourlyData = new ArrayList<>();
+        double cumulative = 0;
+        for (int i = 0; i < 24; i++) {
+            cumulative += hourlySales[i];
+            Map<String, Object> m = new HashMap<>();
+            m.put("hour", i);
+            m.put("customers", hourlyCustomers[i]);
+            m.put("customerUnitPrice", hourlyCustomers[i] > 0 ? hourlySales[i] / hourlyCustomers[i] : 0);
+            m.put("hourSales", hourlySales[i]);
+            m.put("cumulativeSales", cumulative);
+            hourlyData.add(m);
+        }
+
+        model.addAttribute("date", date);
+        model.addAttribute("hourlyData", hourlyData);
+        return "sales-analysis";
+    }
+
+    @GetMapping("/sales-analysis/details")
+    public ResponseEntity<List<Map<String, Object>>> getHourlyDetails(
+            @CookieValue(name = "storeId", required = false) Integer storeId,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam("hour") int hour) {
+        LocalDateTime start = date.atStartOfDay().plusHours(hour);
+        LocalDateTime end = start.plusHours(1);
+        List<Object[]> result = paymentDetailRepository.sumMenuQuantityByTime(storeId, start, end);
+        List<Map<String, Object>> list = new ArrayList<>();
+        for (Object[] r : result) {
+            Map<String, Object> m = new HashMap<>();
+            m.put("menuName", r[0]);
+            m.put("quantity", ((Number) r[1]).intValue());
+            list.add(m);
+        }
+        return ResponseEntity.ok(list);
+    }
+}
+

--- a/PreSotuken/src/main/java/com/order/repository/PaymentDetailRepository.java
+++ b/PreSotuken/src/main/java/com/order/repository/PaymentDetailRepository.java
@@ -24,6 +24,22 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
 
     List<PaymentDetail> findByPaymentPaymentIdAndMenuIsPlanStarterTrue(Integer paymentId);
 
+    @Query("""
+        SELECT pd.menu.menuName, SUM(pd.quantity)
+        FROM PaymentDetail pd
+        JOIN pd.payment p
+        WHERE p.store.storeId = :storeId
+          AND p.paymentTime >= :start AND p.paymentTime < :end
+          AND p.visitCancel = false
+        GROUP BY pd.menu.menuName
+        ORDER BY pd.menu.menuName
+    """)
+    List<Object[]> sumMenuQuantityByTime(
+        @Param("storeId") Integer storeId,
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end
+    );
+
     // 現金売上（点検対象の支払い種別）
 //    @Query("""
 //        SELECT SUM(pd.subtotal)

--- a/PreSotuken/src/main/java/com/order/repository/PaymentRepository.java
+++ b/PreSotuken/src/main/java/com/order/repository/PaymentRepository.java
@@ -18,6 +18,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Integer> {
 
     List<Payment> findByStoreStoreIdOrderByPaymentTimeDesc(Integer storeId);
 
+    List<Payment> findByStoreStoreIdAndPaymentTimeBetween(Integer storeId, LocalDateTime start, LocalDateTime end);
+
 
 
     @Query("""

--- a/PreSotuken/src/main/resources/static/css/sales-analysis.css
+++ b/PreSotuken/src/main/resources/static/css/sales-analysis.css
@@ -1,0 +1,52 @@
+body {
+    font-family: sans-serif;
+    padding: 20px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #f2f2f2;
+}
+
+tbody tr:hover {
+    background-color: #eef;
+    cursor: pointer;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: #fff;
+    margin: 10% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 600px;
+}
+
+.close {
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}

--- a/PreSotuken/src/main/resources/templates/sales-analysis.html
+++ b/PreSotuken/src/main/resources/templates/sales-analysis.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>売上分析</title>
+    <link rel="stylesheet" href="/css/sales-analysis.css">
+</head>
+<body>
+<h1>売上分析</h1>
+<form id="dateForm" method="get" action="/sales-analysis">
+    <label>日付: <input type="date" name="date" th:value="${date}"></label>
+    <button type="submit">表示</button>
+</form>
+<table id="analysisTable">
+    <thead>
+    <tr>
+        <th>時間帯</th>
+        <th>客数</th>
+        <th>客単価</th>
+        <th>売上</th>
+        <th>累計</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="row : ${hourlyData}" th:attr="data-hour=${row.hour}">
+        <td th:text="${row.hour} + ':00 - ' + (${row.hour}+1) + ':00'"></td>
+        <td th:text="${row.customers}"></td>
+        <td th:text="${#numbers.formatDecimal(row.customerUnitPrice,0,0)} + '円'"></td>
+        <td th:text="${#numbers.formatDecimal(row.hourSales,0,0)} + '円'"></td>
+        <td th:text="${#numbers.formatDecimal(row.cumulativeSales,0,0)} + '円'"></td>
+    </tr>
+    </tbody>
+</table>
+<div id="detailModal" class="modal">
+    <div class="modal-content">
+        <span class="close">&times;</span>
+        <div id="modalBody"></div>
+    </div>
+</div>
+<script>
+const modal = document.getElementById('detailModal');
+const modalBody = document.getElementById('modalBody');
+const closeBtn = modal.querySelector('.close');
+closeBtn.onclick = () => modal.style.display = 'none';
+window.onclick = e => { if (e.target === modal) modal.style.display = 'none'; };
+
+document.querySelectorAll('#analysisTable tbody tr').forEach(row => {
+    row.addEventListener('click', () => {
+        const hour = row.dataset.hour;
+        const date = document.querySelector('input[name="date"]').value;
+        fetch(`/sales-analysis/details?date=${date}&hour=${hour}`)
+            .then(res => res.json())
+            .then(data => {
+                let html = `<h2>${hour}時の販売内訳</h2>`;
+                html += '<table><thead><tr><th>商品</th><th>数量</th></tr></thead><tbody>';
+                data.forEach(item => {
+                    html += `<tr><td>${item.menuName}</td><td>${item.quantity}</td></tr>`;
+                });
+                html += '</tbody></table>';
+                modalBody.innerHTML = html;
+                modal.style.display = 'block';
+            });
+    });
+});
+</script>
+</body>
+</html>

--- a/PreSotuken/src/main/resources/templates/seat-list.html
+++ b/PreSotuken/src/main/resources/templates/seat-list.html
@@ -36,6 +36,7 @@
                     <a th:href="@{/admin/cash/history}">入出金履歴</a>
                     <a th:href="@{/payments/history}">会計履歴</a>
                     <a th:href="@{/payment-types}">支払い方法管理</a>
+                    <a th:href="@{/sales-analysis}">売上分析</a>
                 </details>
 
                 <details class="menu-group" close>


### PR DESCRIPTION
## Summary
- Aggregate hourly sales with customer counts and cumulative totals
- Display sales analysis by date with modal drilldown of items sold per hour
- Style new analysis page with basic table and modal CSS

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b78833cf808328b5571f5f536858c1