### PR TITLE
Display tax-inclusive and tax-exclusive totals

### DIFF
--- a/PreSotuken/src/main/java/com/order/repository/PaymentDetailRepository.java
+++ b/PreSotuken/src/main/java/com/order/repository/PaymentDetailRepository.java
@@ -25,7 +25,10 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
     List<PaymentDetail> findByPaymentPaymentIdAndMenuIsPlanStarterTrue(Integer paymentId);
 
     @Query("""
-        SELECT pd.menu.menuName, SUM(pd.quantity), SUM(pd.subtotal)
+        SELECT pd.menu.menuName,
+               SUM(pd.quantity),
+               SUM(pd.subtotal),
+               SUM(pd.subtotal * (1 + pd.taxRate.rate))
 
         FROM PaymentDetail pd
         JOIN pd.payment p

--- a/PreSotuken/src/main/resources/templates/paymentHistory.html
+++ b/PreSotuken/src/main/resources/templates/paymentHistory.html
@@ -21,7 +21,10 @@
     <tr th:each="payment : ${payments}" th:attr="data-payment-id=${payment.paymentId}">
         <td th:text="${#temporals.format(payment.paymentTime, 'yyyy-MM-dd HH:mm')}"></td>
         <td th:text="${payment.visit.seat.seatName}"></td>
-        <td th:text="${#numbers.formatDecimal(payment.total,0,0)} + '円'"></td>
+        <td>
+            <span th:text="${#numbers.formatDecimal(payment.total,0,0)}"></span>円
+            (<span th:text="${#numbers.formatDecimal(subtotalMap[payment.paymentId],0,0)}"></span>円税抜)
+        </td>
         <td th:text="${payment.cashier != null ? payment.cashier.userName : ''}"></td>
     </tr>
     </tbody>
@@ -70,9 +73,11 @@ function loadDetail(id, row) {
             });
             html += `</select></p>`;
             html += `<p>割引: <input type="number" id="discountInput" value="${data.discount || 0}">円</p>`;
-            html += `<table id="detailTable"><thead><tr><th>商品</th><th>数量</th><th>小計</th><th></th></tr></thead><tbody>`;
+            html += `<table id="detailTable"><thead><tr><th>商品</th><th>数量</th><th>税込小計</th><th>税抜小計</th><th></th></tr></thead><tbody>`;
             data.details.forEach(d => {
-                html += `<tr data-detail-id="${d.paymentDetailId}" data-price="${d.price}"><td>${d.menuName}</td><td><input type="number" class="qty-input" min="1" value="${d.quantity}"></td><td class="subtotal">${d.subtotal}</td><td><button type="button" class="delete-detail">削除</button></td></tr>`;
+                const subIn = Math.round(d.subtotalWithTax);
+                const subEx = Math.round(d.subtotalWithoutTax);
+                html += `<tr data-detail-id="${d.paymentDetailId}" data-price="${d.price}" data-tax-rate="${d.taxRate}"><td>${d.menuName}</td><td><input type="number" class="qty-input" min="1" value="${d.quantity}"></td><td class="subtotal">${subIn}円</td><td class="subtotal-ex">${subEx}円</td><td><button type="button" class="delete-detail">削除</button></td></tr>`;
             });
             html += `</tbody></table>`;
             html += `<button id="saveChanges" class="save-btn">保存</button>`;
@@ -81,7 +86,7 @@ function loadDetail(id, row) {
 
             if (row) {
                 row.querySelector('td:nth-child(2)').textContent = data.seatName;
-                row.querySelector('td:nth-child(3)').textContent = `${data.total}円`;
+                row.querySelector('td:nth-child(3)').textContent = `${Math.round(data.total)}円 (税抜 ${Math.round(data.subtotal)}円)`;
                 row.querySelector('td:nth-child(4)').textContent = data.cashierName || '';
             }
 
@@ -97,8 +102,12 @@ function loadDetail(id, row) {
                 input.addEventListener('input', e => {
                     const tr = e.target.closest('tr');
                     const price = parseFloat(tr.dataset.price);
+                    const taxRate = parseFloat(tr.dataset.taxRate);
                     const qty = parseInt(e.target.value) || 0;
-                    tr.querySelector('.subtotal').textContent = price * qty;
+                    const subEx = price * qty;
+                    const subIn = subEx * (1 + taxRate);
+                    tr.querySelector('.subtotal').textContent = `${Math.round(subIn)}円`;
+                    tr.querySelector('.subtotal-ex').textContent = `${Math.round(subEx)}円`;
                 });
             });
 

--- a/PreSotuken/src/main/resources/templates/paymentHistory.html
+++ b/PreSotuken/src/main/resources/templates/paymentHistory.html
@@ -13,7 +13,8 @@
     <tr>
         <th>日時</th>
         <th>席</th>
-        <th>合計</th>
+        <th>税抜合計</th>
+        <th>税込合計</th>
         <th>担当</th>
     </tr>
     </thead>
@@ -21,10 +22,8 @@
     <tr th:each="payment : ${payments}" th:attr="data-payment-id=${payment.paymentId}">
         <td th:text="${#temporals.format(payment.paymentTime, 'yyyy-MM-dd HH:mm')}"></td>
         <td th:text="${payment.visit.seat.seatName}"></td>
-        <td>
-            <span th:text="${#numbers.formatDecimal(payment.total,0,0)}"></span>円
-            (<span th:text="${#numbers.formatDecimal(subtotalMap[payment.paymentId],0,0)}"></span>円税抜)
-        </td>
+        <td><span th:text="${#numbers.formatDecimal(subtotalMap[payment.paymentId],0,0)}"></span>円</td>
+        <td><span th:text="${#numbers.formatDecimal(payment.total,0,0)}"></span>円</td>
         <td th:text="${payment.cashier != null ? payment.cashier.userName : ''}"></td>
     </tr>
     </tbody>
@@ -86,8 +85,9 @@ function loadDetail(id, row) {
 
             if (row) {
                 row.querySelector('td:nth-child(2)').textContent = data.seatName;
-                row.querySelector('td:nth-child(3)').textContent = `${Math.round(data.total)}円 (税抜 ${Math.round(data.subtotal)}円)`;
-                row.querySelector('td:nth-child(4)').textContent = data.cashierName || '';
+                row.querySelector('td:nth-child(3)').textContent = `${Math.round(data.subtotal)}円`;
+                row.querySelector('td:nth-child(4)').textContent = `${Math.round(data.total)}円`;
+                row.querySelector('td:nth-child(5)').textContent = data.cashierName || '';
             }
 
             document.querySelectorAll('.delete-detail').forEach(btn => {

--- a/PreSotuken/src/main/resources/templates/sales-analysis.html
+++ b/PreSotuken/src/main/resources/templates/sales-analysis.html
@@ -18,27 +18,24 @@
     <tr>
         <th>時間帯</th>
         <th>客数</th>
-        <th>客単価</th>
-        <th>売上</th>
-        <th>累計</th>
+        <th>客単価(税抜)</th>
+        <th>客単価(税込)</th>
+        <th>売上(税抜)</th>
+        <th>売上(税込)</th>
+        <th>累計(税抜)</th>
+        <th>累計(税込)</th>
     </tr>
     </thead>
     <tbody>
     <tr th:each="row : ${hourlyData}" th:attr="data-hour=${row.hour}">
         <td th:text="${row.hour} + ':00 - ' + (${row.hour}+1) + ':00'"></td>
         <td th:text="${row.customers}"></td>
-        <td>
-            <span th:text="${#numbers.formatDecimal(row.customerUnitPriceWithTax,0,0)}"></span>円
-            (<span th:text="${#numbers.formatDecimal(row.customerUnitPriceWithoutTax,0,0)}"></span>円税抜)
-        </td>
-        <td>
-            <span th:text="${#numbers.formatDecimal(row.hourSalesWithTax,0,0)}"></span>円
-            (<span th:text="${#numbers.formatDecimal(row.hourSalesWithoutTax,0,0)}"></span>円税抜)
-        </td>
-        <td>
-            <span th:text="${#numbers.formatDecimal(row.cumulativeSalesWithTax,0,0)}"></span>円
-            (<span th:text="${#numbers.formatDecimal(row.cumulativeSalesWithoutTax,0,0)}"></span>円税抜)
-        </td>
+        <td><span th:text="${#numbers.formatDecimal(row.customerUnitPriceWithoutTax,0,0)}"></span>円</td>
+        <td><span th:text="${#numbers.formatDecimal(row.customerUnitPriceWithTax,0,0)}"></span>円</td>
+        <td><span th:text="${#numbers.formatDecimal(row.hourSalesWithoutTax,0,0)}"></span>円</td>
+        <td><span th:text="${#numbers.formatDecimal(row.hourSalesWithTax,0,0)}"></span>円</td>
+        <td><span th:text="${#numbers.formatDecimal(row.cumulativeSalesWithoutTax,0,0)}"></span>円</td>
+        <td><span th:text="${#numbers.formatDecimal(row.cumulativeSalesWithTax,0,0)}"></span>円</td>
     </tr>
     </tbody>
 </table>

--- a/PreSotuken/src/main/resources/templates/sales-analysis.html
+++ b/PreSotuken/src/main/resources/templates/sales-analysis.html
@@ -27,9 +27,18 @@
     <tr th:each="row : ${hourlyData}" th:attr="data-hour=${row.hour}">
         <td th:text="${row.hour} + ':00 - ' + (${row.hour}+1) + ':00'"></td>
         <td th:text="${row.customers}"></td>
-        <td th:text="${#numbers.formatDecimal(row.customerUnitPrice,0,0)} + '円'"></td>
-        <td th:text="${#numbers.formatDecimal(row.hourSales,0,0)} + '円'"></td>
-        <td th:text="${#numbers.formatDecimal(row.cumulativeSales,0,0)} + '円'"></td>
+        <td>
+            <span th:text="${#numbers.formatDecimal(row.customerUnitPriceWithTax,0,0)}"></span>円
+            (<span th:text="${#numbers.formatDecimal(row.customerUnitPriceWithoutTax,0,0)}"></span>円税抜)
+        </td>
+        <td>
+            <span th:text="${#numbers.formatDecimal(row.hourSalesWithTax,0,0)}"></span>円
+            (<span th:text="${#numbers.formatDecimal(row.hourSalesWithoutTax,0,0)}"></span>円税抜)
+        </td>
+        <td>
+            <span th:text="${#numbers.formatDecimal(row.cumulativeSalesWithTax,0,0)}"></span>円
+            (<span th:text="${#numbers.formatDecimal(row.cumulativeSalesWithoutTax,0,0)}"></span>円税抜)
+        </td>
     </tr>
     </tbody>
 </table>
@@ -54,10 +63,11 @@ document.querySelectorAll('#analysisTable tbody tr').forEach(row => {
             .then(res => res.json())
             .then(data => {
                 let html = `<h2>${hour}時の販売内訳</h2>`;
-                html += '<table><thead><tr><th>商品</th><th>数量</th><th>金額</th></tr></thead><tbody>';
+                html += '<table><thead><tr><th>商品</th><th>数量</th><th>税込金額</th><th>税抜金額</th></tr></thead><tbody>';
                 data.forEach(item => {
-                    const price = Math.round(item.price).toLocaleString();
-                    html += `<tr><td>${item.menuName}</td><td>${item.quantity}</td><td>${price}円</td></tr>`;
+                    const priceIn = Math.round(item.priceWithTax).toLocaleString();
+                    const priceEx = Math.round(item.priceWithoutTax).toLocaleString();
+                    html += `<tr><td>${item.menuName}</td><td>${item.quantity}</td><td>${priceIn}円</td><td>${priceEx}円</td></tr>`;
 
                 });
                 html += '</tbody></table>';


### PR DESCRIPTION
## Summary
- show both tax-inclusive and tax-exclusive values in sales analysis
- expose inclusive/exclusive totals for payment history and details
- query payment details for subtotals with tax

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b7994c6cc083289e4a23eec8fd66de