### PR TITLE
Support cancelling and restoring payment history

### DIFF
--- a/PreSotuken/src/main/java/com/order/controller/PaymentController.java
+++ b/PreSotuken/src/main/java/com/order/controller/PaymentController.java
@@ -161,6 +161,7 @@ public class PaymentController {
         result.put("discount", payment.getDiscount());
         result.put("total", payment.getTotal());
         result.put("subtotal", subtotal);
+        result.put("cancel", Boolean.TRUE.equals(payment.getCancel()));
         result.put("details", detailList);
         result.put("seats", seatList);
         result.put("users", userList);
@@ -242,6 +243,27 @@ public class PaymentController {
         payment.setTotal(subtotal - discount);
         paymentRepository.save(payment);
 
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/payments/history/{paymentId}/cancel")
+    public ResponseEntity<Void> updatePaymentCancellation(
+            @CookieValue(name = "storeId", required = false) Integer storeId,
+            @PathVariable("paymentId") Integer paymentId,
+            @RequestBody Map<String, Boolean> body) {
+
+        Payment payment = paymentRepository.findById(paymentId).orElse(null);
+        if (payment == null || !payment.getStore().getStoreId().equals(storeId)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Boolean cancel = body.get("cancel");
+        if (cancel == null) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        payment.setCancel(cancel);
+        paymentRepository.save(payment);
         return ResponseEntity.ok().build();
     }
 

--- a/PreSotuken/src/main/java/com/order/entity/Payment.java
+++ b/PreSotuken/src/main/java/com/order/entity/Payment.java
@@ -27,9 +27,12 @@ public class Payment {
     @ManyToOne
     @JoinColumn(name = "visit_id")
     private Visit visit;
-    
+
     @Column(name = "visit_cancel", nullable = false)
     private Boolean visitCancel = false;
+
+    @Column(name = "cancel", nullable = false)
+    private Boolean cancel = false;
 
     private LocalDateTime paymentTime;
     private Double subtotal;

--- a/PreSotuken/src/main/java/com/order/repository/PaymentDetailRepository.java
+++ b/PreSotuken/src/main/java/com/order/repository/PaymentDetailRepository.java
@@ -35,6 +35,7 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
         WHERE p.store.storeId = :storeId
           AND p.paymentTime >= :start AND p.paymentTime < :end
           AND p.visitCancel = false
+          AND p.cancel = false
         GROUP BY pd.menu.menuName
         ORDER BY pd.menu.menuName
     """)
@@ -71,6 +72,7 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
           AND p.paymentTime BETWEEN :start AND :end
           AND pt.isInspectionTarget = true
           AND p.visitCancel = false
+          AND p.cancel = false
         GROUP BY pd.taxRate.taxRateId
     """)
     List<Object[]> sumSalesByTaxRate(
@@ -88,6 +90,7 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
         WHERE p.store.storeId = :storeId
           AND p.paymentTime BETWEEN :start AND :end
           AND p.visitCancel = false
+          AND p.cancel = false
         GROUP BY pt.typeName
     """)
     List<Object[]> sumSalesByPaymentType(
@@ -106,6 +109,7 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
           AND p.paymentTime BETWEEN :start AND :end
           AND pd.discount IS NOT NULL
           AND p.visitCancel = false
+          AND p.cancel = false
         GROUP BY pt.typeName
     """)
     List<Object[]> sumDiscountByPaymentType(
@@ -122,6 +126,7 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
         WHERE p.store.storeId = :storeId
           AND p.paymentTime BETWEEN :start AND :end
           AND p.visitCancel = false
+          AND p.cancel = false
     """)
     BigDecimal sumTotalSales(
         @Param("storeId") Integer storeId,
@@ -134,10 +139,11 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
     	    SELECT SUM(pd.subtotal * pd.taxRate.rate)
     	    FROM PaymentDetail pd
     	    JOIN pd.payment p
-    	    WHERE p.store.storeId = :storeId
-    	      AND p.paymentTime BETWEEN :start AND :end
-    	      AND p.visitCancel = false
-    	      AND pd.taxRate.rate = :rate
+            WHERE p.store.storeId = :storeId
+              AND p.paymentTime BETWEEN :start AND :end
+              AND p.visitCancel = false
+              AND p.cancel = false
+              AND pd.taxRate.rate = :rate
     	""")
     	BigDecimal sumTaxAmount(
     	    @Param("storeId") Integer storeId,
@@ -163,6 +169,7 @@ public interface PaymentDetailRepository extends JpaRepository<PaymentDetail, In
           AND p.paymentTime >= :start
           AND p.paymentTime < :end
           AND p.visitCancel = false
+          AND p.cancel = false
         GROUP BY pt.typeName, tr.taxRateId
         ORDER BY pt.typeName, tr.taxRateId
     """)

--- a/PreSotuken/src/main/java/com/order/repository/PaymentRepository.java
+++ b/PreSotuken/src/main/java/com/order/repository/PaymentRepository.java
@@ -29,7 +29,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Integer> {
           AND p.paymentTime >= :start
           AND p.paymentTime < :end
           AND p.visitCancel = false
-          AND p.cancel = false
+          AND COALESCE(p.cancel, false) = false
     """)
     Long countCustomerVisits(
         @Param("storeId") Integer storeId,
@@ -42,7 +42,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Integer> {
             WHERE p.store.storeId = :storeId
               AND p.paymentTime BETWEEN :start AND :end
               AND p.visitCancel = false
-              AND p.cancel = false
+              AND COALESCE(p.cancel, false) = false
               AND p.paymentType.isInspectionTarget = true
     	""")
     	BigDecimal sumCashSales(

--- a/PreSotuken/src/main/java/com/order/repository/PaymentRepository.java
+++ b/PreSotuken/src/main/java/com/order/repository/PaymentRepository.java
@@ -29,6 +29,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Integer> {
           AND p.paymentTime >= :start
           AND p.paymentTime < :end
           AND p.visitCancel = false
+          AND p.cancel = false
     """)
     Long countCustomerVisits(
         @Param("storeId") Integer storeId,
@@ -38,10 +39,11 @@ public interface PaymentRepository extends JpaRepository<Payment, Integer> {
     @Query("""
     	    SELECT SUM(p.total)
     	    FROM Payment p
-    	    WHERE p.store.storeId = :storeId
-    	      AND p.paymentTime BETWEEN :start AND :end
-    	      AND p.visitCancel = false
-    	      AND p.paymentType.isInspectionTarget = true
+            WHERE p.store.storeId = :storeId
+              AND p.paymentTime BETWEEN :start AND :end
+              AND p.visitCancel = false
+              AND p.cancel = false
+              AND p.paymentType.isInspectionTarget = true
     	""")
     	BigDecimal sumCashSales(
     	    @Param("storeId") Integer storeId,

--- a/PreSotuken/src/main/resources/static/css/payment-history.css
+++ b/PreSotuken/src/main/resources/static/css/payment-history.css
@@ -23,6 +23,50 @@ tbody tr:hover {
     cursor: pointer;
 }
 
+.cancelled-row {
+    background-color: #fbeaea;
+}
+
+.status-cell {
+    width: 70px;
+    text-align: center;
+    font-weight: bold;
+}
+
+.cancelled-row td {
+    color: #555;
+}
+
+.cancelled-row .status-cell {
+    color: #c00;
+}
+
+.cancel-status {
+    display: inline-block;
+    margin-right: 10px;
+    font-weight: bold;
+}
+
+.status-active {
+    color: #2b8a3e;
+}
+
+.status-cancelled {
+    color: #c00;
+}
+
+.cancel-toggle-btn {
+    margin-bottom: 10px;
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    background-color: #f5f5f5;
+    cursor: pointer;
+}
+
+.cancel-toggle-btn:hover {
+    background-color: #e2e2e2;
+}
+
 .back-button {
     display: inline-block;
     margin-bottom: 10px;

--- a/PreSotuken/src/main/resources/templates/paymentHistory.html
+++ b/PreSotuken/src/main/resources/templates/paymentHistory.html
@@ -11,6 +11,7 @@
 <table id="historyTable">
     <thead>
     <tr>
+        <th>状態</th>
         <th>日時</th>
         <th>席</th>
         <th>税抜合計</th>
@@ -19,7 +20,10 @@
     </tr>
     </thead>
     <tbody>
-    <tr th:each="payment : ${payments}" th:attr="data-payment-id=${payment.paymentId}">
+    <tr th:each="payment : ${payments}"
+        th:attr="data-payment-id=${payment.paymentId}"
+        th:classappend="${payment.cancel} ? ' cancelled-row' : ''">
+        <td class="status-cell" th:text="${payment.cancel} ? '削除済' : ''"></td>
         <td th:text="${#temporals.format(payment.paymentTime, 'yyyy-MM-dd HH:mm')}"></td>
         <td th:text="${payment.visit.seat.seatName}"></td>
         <td><span th:text="${#numbers.formatDecimal(subtotalMap[payment.paymentId],0,0)}"></span>円</td>
@@ -55,7 +59,13 @@ function loadDetail(id, row) {
     fetch(`/payments/history/${id}`)
         .then(res => res.json())
         .then(data => {
+            const isCancelled = data.cancel === true;
+            const statusText = isCancelled ? '削除済み' : '有効';
+            const statusClass = isCancelled ? 'status-cancelled' : 'status-active';
+
             let html = `<h2>会計詳細</h2>`;
+            html += `<p>状態: <span id="cancelStatus" class="cancel-status ${statusClass}">${statusText}</span></p>`;
+            html += `<button id="toggleCancel" class="cancel-toggle-btn">${isCancelled ? '復元する' : '削除する'}</button>`;
             html += `<p>席: <select id="seatSelect">`;
             data.seats.forEach(s => {
                 html += `<option value="${s.id}" ${s.id===data.seatId?'selected':''}>${s.name}</option>`;
@@ -84,10 +94,15 @@ function loadDetail(id, row) {
             modal.style.display = 'block';
 
             if (row) {
-                row.querySelector('td:nth-child(2)').textContent = data.seatName;
-                row.querySelector('td:nth-child(3)').textContent = `${Math.round(data.subtotal)}円`;
-                row.querySelector('td:nth-child(4)').textContent = `${Math.round(data.total)}円`;
-                row.querySelector('td:nth-child(5)').textContent = data.cashierName || '';
+                const statusCell = row.querySelector('td:nth-child(1)');
+                if (statusCell) {
+                    statusCell.textContent = isCancelled ? '削除済' : '';
+                }
+                row.classList.toggle('cancelled-row', isCancelled);
+                row.querySelector('td:nth-child(3)').textContent = data.seatName;
+                row.querySelector('td:nth-child(4)').textContent = `${Math.round(data.subtotal)}円`;
+                row.querySelector('td:nth-child(5)').textContent = `${Math.round(data.total)}円`;
+                row.querySelector('td:nth-child(6)').textContent = data.cashierName || '';
             }
 
             document.querySelectorAll('.delete-detail').forEach(btn => {
@@ -138,6 +153,21 @@ function loadDetail(id, row) {
                     }
                 });
             });
+
+            const toggleBtn = document.getElementById('toggleCancel');
+            if (toggleBtn) {
+                toggleBtn.addEventListener('click', () => {
+                    fetch(`/payments/history/${id}/cancel`, {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({cancel: !isCancelled})
+                    }).then(res => {
+                        if (res.ok) {
+                            loadDetail(id, row);
+                        }
+                    });
+                });
+            }
         });
 }
 


### PR DESCRIPTION
## Summary
- add a cancel flag to payments so cancelled records can be restored and are dropped from inspection aggregates
- expose cancellation toggling in the payment history modal and show the status in a new table column
- update repository queries and styling to highlight cancelled payments in the UI

## Testing
- `./gradlew test` *(fails: 403 Forbidden downloading spring-boot-starter-test)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cbd7da58832890fe0ff49676ad6b